### PR TITLE
Fix/result count for toggles

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -128,7 +128,7 @@ const appTitle = computed(() => {
         spin
       />
       <div class="mt-6">
-        Loading {{ appTitle.toLowerCase() }}
+        Loading {{ appTitle.toUpperCase() }}
       </div>
     </div>
   </div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -128,7 +128,7 @@ const appTitle = computed(() => {
         spin
       />
       <div class="mt-6">
-        Loading {{ appTitle.toUpperCase() }}
+        Loading {{ appTitle.toLowerCase() }}
       </div>
     </div>
   </div>

--- a/src/components/RefinePanel.vue
+++ b/src/components/RefinePanel.vue
@@ -106,6 +106,7 @@ const selectedArray = computed(() => {
   const compiled = [];
   if (Object.keys(selL).length) {
     Object.keys(selL).forEach((value) => {
+
       const valSplit = value.split('_')[0];
       if (valSplit === 'radio' && !(typeof selL[value] === 'string')) {
         compiled.push(selL[value][0]);
@@ -124,17 +125,6 @@ const selectedArray = computed(() => {
 
 const selectedServices = computed(() => { return MainStore.selectedServices });
 const timesIconWeight = computed(() => { return findIconDefinition({ prefix: 'far', iconName: 'times' }) ? 'far' : 'fas' });
-
-const toggleKeys = computed(() => {
-  const toggles = [];
-  if (!Object.keys($config.refine).includes('multipleFieldGroups') && !Object.keys($config.refine).includes('multipleDependentFieldGroups')) return toggles;
-  const entries = Object.keys($config.refine).includes('multipleFieldGroups') ? Object.entries($config.refine.multipleFieldGroups) : Object.entries($config.refine.multipleDependentFieldGroups);
-  entries.forEach((entry) => {
-    if (Object.keys(entry[1]).includes('toggleable') && entry[1].toggleable) { toggles.push(entry[1].toggleKey) }
-  })
-  return toggles;
-})
-
 const zipcodeEntered = computed(() => { return MainStore.selectedZipcode });
 
 // WATCHERS
@@ -149,7 +139,7 @@ watch(
 watch(
   () => selectedServices.value.length,
   async nextSelectedServices => {
-    if (import.meta.env.VITE_DEBUG) console.log('RefinePanel watch selectedServices is firing, selectedServices.value:', selectedServices.value);
+    // if (import.meta.env.VITE_DEBUG) console.log('RefinePanel watch selectedServices is firing, selectedServices.value:', selectedServices.value);
     selected.value = selectedServices.value.length ?
       $config.refine.type === 'categoryField_value' ? selectedServices.value[0] : selectedServices.value :
       $config.refine.type === 'categoryField_value' ? null : [];
@@ -322,10 +312,7 @@ const closeZipcodeBox = (e, box) => {
 
 const expandCheckbox = (ind) => { refineList.value[ind].expanded = !refineList.value[ind].expanded };
 const expandRefine = () => { MainStore.refineOpen = !MainStore.refineOpen };
-const getBoxValue = (box) => {
-  const keys = toggleKeys.value;
-  return (box && typeof box != 'object') ? box.replace("_", ".") : null
-};
+const getBoxValue = (box) => { return (box && typeof box != 'object') ? box.replace("_", ".") : null };
 
 const getCategoryFieldValue = (selected) => {
   // if (import.meta.env.VITE_DEBUG) console.log('getCategoryFieldValue is running, selected:', selected);
@@ -628,7 +615,7 @@ const refineListTranslated_default = () => {
 
                 <tooltip-checkbox v-if="refineListTranslated[ind]['checkbox']"
                   :options="refineListTranslated[ind]['checkbox']" :small="!isMobile"
-                  :toggleKey="$config.refine.multipleFieldGroups[ind].toggleKey ? $config.refine.multipleFieldGroups[ind].toggleKey : ''""
+                  :toggleKey="$config.refine.multipleFieldGroups[ind].toggleKey ? $config.refine.multipleFieldGroups[ind].toggleKey : ''"
                   :num-of-columns="calculateColumns(refineList[ind]['checkbox'], ind)"
                   v-model="selectedList['checkbox_' + ind]" text-key="textLabel" value-key="data" shrinkToFit="true">
                 </tooltip-checkbox>

--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -32,20 +32,20 @@ export const useDataStore = defineStore('DataStore', {
         'f': 'json',
         'username': import.meta.env.VITE_AGO_USERNAME,
         'password': import.meta.env.VITE_AGO_PASSWORD,
-        'referer': 'https://www.mydomain.com' 
+        'referer': 'https://www.mydomain.com'
       });
-    
+
       let config = {
         method: 'post',
         maxBodyLength: Infinity,
         url: 'https://www.arcgis.com/sharing/rest/generateToken',
-        headers: { 
-          'Content-Type': 'application/x-www-form-urlencoded', 
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
           // 'Authorization': 'Basic Og=='
         },
         data : data
       };
-    
+
       await axios.request(config)
       .then((response) => {
         if (import.meta.env.VITE_DEBUG) console.log(JSON.stringify(response.data));
@@ -59,13 +59,13 @@ export const useDataStore = defineStore('DataStore', {
       const $config = useConfigStore().config;
 
       for (let source in $config.dataSources) {
-        
+
         const dataConfig = $config.dataSources[source];
         const params = dataConfig.options.params;
         if ($config.agoTokenNeeded) {
           params.token = this.agoToken.token;
         };
-        
+
         let dependent;
         if (dataConfig.dependent) {
           dependent = this.sources[dataConfig.dependent];
@@ -84,7 +84,7 @@ export const useDataStore = defineStore('DataStore', {
           response = await axios.get(dataConfig.url, { params } );
         }
         if (import.meta.env.VITE_DEBUG) console.log('fillResources is running, params:', params, 'response:', response);
-        
+
         if (response.status === 200) {
           let data = await response.data;
 
@@ -96,7 +96,7 @@ export const useDataStore = defineStore('DataStore', {
               dataConfig.options.success(data, dependent);
             }
           }
-    
+
           if (data.features) {
             if (import.meta.env.VITE_DEBUG) console.log('first option, data.features.length:', data.features.length);
             // data.features = data.features.filter(item => item.geometry);


### PR DESCRIPTION
tested the count with primary care finder to make sure new code doesn't break the existing apps
number or results will now reflect the correct total based on the status of toggles
parent App passes a function to Pinboard that pinboard will use to generate a bit array to get the counts that result from toggles being applied in the refinePanel