### PR TITLE
fix geolocate button by raising timeout from 1s to 10s

### DIFF
--- a/src/stores/MapStore.js
+++ b/src/stores/MapStore.js
@@ -53,7 +53,7 @@ export const useMapStore = defineStore("MapStore", {
     async geolocate() {
       if (import.meta.env.VITE_DEBUG) console.log('geolocate is running');
       if (!this.geolocation) {
-        navigator.geolocation.getCurrentPosition(this.geofindSuccess, this.geofindError, { enableHighAccuracy: true, timeout: 1000, maximumAge: 0, distanceFilter: 5 });
+        navigator.geolocation.getCurrentPosition(this.geofindSuccess, this.geofindError, { enableHighAccuracy: true, timeout: 10000, maximumAge: 0, distanceFilter: 5 });
       } else {
         this.geolocation = null;
         this.bufferForAddressOrLocationOrZipcode = null;


### PR DESCRIPTION
navigator.geolocation.getCurrentPosition was called with timeout: 1000, maximumAge: 0, enableHighAccuracy: true. Browsers used to return a network/IP-derived position in well under 1s; tightened modern behavior honors maximumAge: 0 and enableHighAccuracy more strictly, so the call times out (code 3) before a fix is available. geofindError only logs under VITE_DEBUG, so failures were silent in production builds.

10s gives a realistic ceiling for a real WiFi/GPS fix while still short-circuiting if the device truly can't locate.